### PR TITLE
api/usersに対するPOSTの実装

### DIFF
--- a/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/AsyncCallback.java
+++ b/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/AsyncCallback.java
@@ -1,0 +1,5 @@
+package com.example.haseyuuki.fujitsuchizaihase;
+
+public interface AsyncCallback {
+    void onComplete(String result);
+}

--- a/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/AsyncHttpPostRequest.java
+++ b/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/AsyncHttpPostRequest.java
@@ -1,0 +1,30 @@
+package com.example.haseyuuki.fujitsuchizaihase;
+
+public class AsyncHttpPostRequest extends AsyncHttpRequest {
+
+    public AsyncHttpPostRequest(AsyncCallback callback) {
+        super.callback = callback;
+    }
+
+    /***
+     * POST送信を非同期で処理します。
+     * @param params [0]: 送信先URL
+     *               [1]: 送信するJSONデータ
+     * @return POST送信のレスポンス
+     */
+    @Override
+    protected String doInBackground(String... params) {
+        String address = params[0];
+        String json = params[1];
+        return HttpJson.Post(address, json);
+    }
+
+    // 処理が終了したら結果をcallbackに投げる
+    @Override
+    protected void onPostExecute(String result) {
+        super.onPostExecute(result);
+        if (callback != null) {
+            callback.onComplete(result);
+        }
+    }
+}

--- a/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/AsyncHttpRequest.java
+++ b/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/AsyncHttpRequest.java
@@ -1,0 +1,7 @@
+package com.example.haseyuuki.fujitsuchizaihase;
+
+import android.os.AsyncTask;
+
+public abstract class AsyncHttpRequest extends AsyncTask<String, Void, String> {
+    protected AsyncCallback callback = null;
+}

--- a/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/FujitsuAPI.java
+++ b/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/FujitsuAPI.java
@@ -452,4 +452,11 @@ public class FujitsuAPI {
     }
 
 
+    public static class Users {
+        private static final String endpoint = "http://fujitsu-chizai.azurewebsites.net/api/users";
+
+        public static void register(User user, AsyncCallback callback) {
+            new AsyncHttpPostRequest(callback).execute(endpoint, ParseJson.toJson(user));
+        }
+    }
 }

--- a/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/HttpJson.java
+++ b/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/HttpJson.java
@@ -1,11 +1,11 @@
 package com.example.haseyuuki.fujitsuchizaihase;
 
-import android.util.Log;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -55,7 +55,7 @@ public class HttpJson {
     }
 
     //取得したストリームを文字列に変換するメソッド
-    public String InputStreamToString(InputStream is) throws IOException {
+    public static String InputStreamToString(InputStream is) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(is));
         StringBuilder sb = new StringBuilder();
         String line;
@@ -66,6 +66,45 @@ public class HttpJson {
         return sb.toString();
     }
 
+    public static String Post(String address, String json) {
+        String response = null;
+        HttpURLConnection con = null;
+        try {
+            // 設定
+            URL url = new URL(address);
+            con = (HttpURLConnection)url.openConnection();
+            con.setReadTimeout(10000);
+            con.setConnectTimeout(20000);
+            con.setRequestMethod("POST");
+            con.setInstanceFollowRedirects(false);
+            con.setRequestProperty("Accept-Language", "jp");
+            con.setDoOutput(true);
+            con.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+
+            // 送信
+            OutputStream os = con.getOutputStream();
+            PrintStream ps = new PrintStream(os);
+            ps.print(json);
+            ps.close();
+
+            // 受信
+            int res = con.getResponseCode();
+            switch (res){
+                case HttpURLConnection.HTTP_OK:
+                    InputStream is = con.getInputStream();
+                    response = InputStreamToString(is);
+                    is.close();
+                    break;
+                case HttpURLConnection.HTTP_BAD_REQUEST:
+                    throw new Exception("HTTP_BAD_REQUEST");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            con.disconnect();
+        }
+        return  response;
+    }
 }
 
 /*

--- a/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/ParseJson.java
+++ b/FujitsuChizaiHase/app/src/main/java/com/example/haseyuuki/fujitsuchizaihase/ParseJson.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
  * Created by haseyuuki on 2016/09/05.
  */
 public class ParseJson {
-    private Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss").create();
+    private static Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss").create();
     private PlaceMark placemark1 = new PlaceMark();
     private PlaceList placelist1 = new PlaceList();
     private User user1 = new User();
@@ -33,9 +33,8 @@ public class ParseJson {
 
 
     //Jsonから　User単体へパースを行う
-    public User parseUser(String json) throws JSONException {
-        user1 = gson.fromJson(json, User.class);
-        return  user1;
+    public static User parseUser(String json) throws JSONException {
+        return gson.fromJson(json, User.class);
     }
     //Jsonから　User配列へパースを行う
     public UserList parseUserList(String json) throws JSONException {
@@ -66,7 +65,9 @@ public class ParseJson {
         return geocode;
     }
 
-
+    public static String toJson(Object obj) {
+        return gson.toJson(obj);
+    }
 
 }
 


### PR DESCRIPTION
ユーザ情報をサーバに登録できるようにしました。
以下は、「1993年日本生まれ性別不明」のユーザを登録するサンプルコードです。

``` java
// 登録ユーザの情報設定
User user = new User();
user.bornIn = 1993;
user.country = Countries.Japan;
user.sex = Sexes.NotApplicable;

// 登録実行
FujitsuAPI.Users.register(user, new AsyncCallback() {
    @Override
    // 登録した結果はコールバック内で処理
    public void onComplete(String result) {
        if (result == null) return;
        try {
            User res = ParseJson.parseUser(result);
            Log.d("", "id:" + res.id + " createdAt:" + res.createdAt);
        } catch (Exception e) { /*何もしないんだよ*/ }
    }
});
```

実装にあたって、いくつかの既存のメソッド・メンバ変数をstaticに変更してしまいました:tired_face:
HttpJsonは通信処理をまとめたクラスであり、ParseJsonはGSONによるパース処理のラッパーであるように見えます。そのため、これらクラスは状態を持たなくてもよく、staticクラスとして定義するほうが適切なように思いました:thumbsup:

Pull Request内容を確認の上、問題なさそうであればMergeをお願いします:pray:
